### PR TITLE
Added parsing of latest_receipt_info array

### DIFF
--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -59,7 +59,8 @@ module Venice
         original_application_version: @original_application_version,
         creation_date: (@creation_date.httpdate rescue nil),
         expiration_date: (@expiration_date.httpdate rescue nil),
-        in_app: @in_app.map{ |iap| iap.to_h }
+        in_app: @in_app.map{ |iap| iap.to_h },
+        latest_receipt_info: @latest_receipt_info.map{ |iap| iap.to_h }
       }
     end
     alias_method :to_h, :to_hash

--- a/lib/venice/receipt.rb
+++ b/lib/venice/receipt.rb
@@ -26,7 +26,8 @@ module Venice
     # Original json response from AppStore
     attr_reader :original_json_response
 
-    attr_accessor :latest_receipt_info
+    # Undocumented, but will hold some receipts for payments that may not yet be in-app (i.e. subscription payments triggered by the backend)
+    attr_reader :latest_receipt_info
     
     def initialize(attributes = {})
       @original_json_response = attributes['original_json_response']
@@ -44,6 +45,11 @@ module Venice
       attributes['in_app'].each do |iap_attributes|
         @in_app << InAppReceipt.new(iap_attributes)
       end if attributes['in_app']
+
+      @latest_receipt_info = []
+      attributes['latest_receipt_info'].each do |iap_attributes|
+        @latest_receipt_info << InAppReceipt.new(iap_attributes)
+      end if attributes['latest_receipt_info']
     end
 
     def to_hash

--- a/spec/receipt_spec.rb
+++ b/spec/receipt_spec.rb
@@ -36,6 +36,22 @@ describe Venice::Receipt do
               "expires_date" => "2014-06-28 14:47:53 Etc/GMT",
               "is_trial_period" => "false"
             }
+          ],
+          "latest_receipt_info" => [
+            {
+              "quantity" => "1",
+              "product_id" => "com.foo.product1",
+              "transaction_id" => "1000000070107111",
+              "original_transaction_id" => "1000000061051111",
+              "purchase_date" => "2014-05-28 14:47:53 Etc/GMT",
+              "purchase_date_ms" => "1401288473000",
+              "purchase_date_pst" => "2014-05-28 07:47:53 America/Los_Angeles",
+              "original_purchase_date" => "2014-05-28 14:47:53 Etc/GMT",
+              "original_purchase_date_ms" => "1401288473000",
+              "original_purchase_date_pst" => "2014-05-28 07:47:53 America/Los_Angeles",
+              "expires_date" => "2014-06-28 14:47:53 Etc/GMT",
+              "is_trial_period" => "false"
+            }
           ]
         }
       }
@@ -49,6 +65,8 @@ describe Venice::Receipt do
     its(:original_application_version) { "1" }
     its(:expiration_date) { should be_instance_of DateTime }
     its(:creation_date) { should be_instance_of DateTime }
+    its(:latest_receipt_info) { should be_instance_of Array }
+    its('latest_receipt_info.length') { should eq(1) }
 
     describe "#verify!" do
 


### PR DESCRIPTION
This adds support for the `latest_receipt_info` array, which, while undocumented, is the only way to verify from the server side that payments have been made (or not made) if the app hasn't been launched.